### PR TITLE
Add support to launch bootstrap when cwd is not at the project dir

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -4,4 +4,6 @@
 #&& automake --gnu --add-missing \
 #&& autoconf
 
+_here=$(dirname $0)
+cd $_here || exit
 autoreconf --install


### PR DESCRIPTION
When launch bootstrap from external directory or double click bootstrap (cwd not set to the dirname of bootstrap it is depend on filemanager and terminal setting), it won't work properly before. Add some command before autoreconf to make bootstrap work nicely in these situation.