### PR TITLE
Make xCHM faster

### DIFF
--- a/src/chmfile.cpp
+++ b/src/chmfile.cpp
@@ -41,6 +41,7 @@ constexpr size_t MAX_SEARCH_RESULTS {512};
 // Big-enough buffer size for use with various routines.
 constexpr size_t BUF_SIZE {4096};
 
+#ifndef _WIN32
 // Thanks to Vadim Zeitlin.
 constexpr int ANSI_CHARSET {0};
 constexpr int SHIFTJIS_CHARSET {128};
@@ -106,6 +107,7 @@ constexpr uint32_t LANG_UZBEK {0x43};
 constexpr uint32_t LANG_TATAR {0x44};
 constexpr uint32_t LANG_MONGOLIAN {0x50};
 constexpr uint32_t LANG_GALICIAN {0x56};
+#endif
 
 #define FIXENDIAN16(x) (x = wxUINT16_SWAP_ON_BE(x))
 #define FIXENDIAN32(x) (x = wxUINT32_SWAP_ON_BE(x))

--- a/src/chmfile.cpp
+++ b/src/chmfile.cpp
@@ -550,6 +550,7 @@ bool CHMFile::GetIndex(CHMListCtrl& toBuild)
 
     toBuild.Freeze();
     bool bindex = BinaryIndex(toBuild, *cvPtr);
+    toBuild.UpdateItemCount();
     toBuild.Thaw();
 
     if (bindex)

--- a/src/chmframe.cpp
+++ b/src/chmframe.cpp
@@ -397,7 +397,7 @@ void CHMFrame::OnRemoveBookmark(wxCommandEvent&)
         _cb->SetSelection(0);
         _bookmarkSel = true;
     } else
-        _cb->ChangeValue(wxEmptyString);
+        _cb->Clear();
 }
 
 void CHMFrame::OnBookmarkSel(wxCommandEvent& event)
@@ -748,7 +748,6 @@ wxPanel* CHMFrame::CreateContentsPanel()
 void CHMFrame::LoadBookmarks()
 {
     _cb->Clear();
-    _cb->ChangeValue(wxEmptyString);
 
     auto chmf = CHMInputStream::GetCache();
 

--- a/src/chmhtmlwindow.cpp
+++ b/src/chmhtmlwindow.cpp
@@ -100,11 +100,9 @@ void CHMHtmlWindow::Sync(wxTreeItemId root, const wxString& page)
     }
 
     wxTreeItemIdValue cookie;
-    auto              child = _tcl->GetFirstChild(root, cookie);
 
-    for (auto i = 0UL; i < _tcl->GetChildrenCount(root, false); ++i) {
+    for (auto child = _tcl->GetFirstChild(root, cookie); child; child = _tcl->GetNextChild(root, cookie)) {
         Sync(child, page);
-        child = _tcl->GetNextChild(root, cookie);
     }
 }
 

--- a/src/chmlistctrl.cpp
+++ b/src/chmlistctrl.cpp
@@ -59,10 +59,14 @@ void CHMListCtrl::Reset()
     UpdateUI();
 }
 
+void CHMListCtrl::UpdateItemCount()
+{
+    SetItemCount(_items.GetCount());
+}
+
 void CHMListCtrl::AddPairItem(const wxString& title, const wxString& url)
 {
     _items.Add(new CHMListPairItem(title, url));
-    SetItemCount(_items.GetCount());
 }
 
 void CHMListCtrl::LoadSelected()

--- a/src/chmlistctrl.h
+++ b/src/chmlistctrl.h
@@ -73,6 +73,8 @@ public:
     //! Cleans up and removes all the list items.
     void Reset();
 
+    void UpdateItemCount();
+
     /*!
       \brief Adds a title:url pair to the list. The title is the part
       that gets displayed, the url is tha page where the HTML window

--- a/src/chmsearchpanel.cpp
+++ b/src/chmsearchpanel.cpp
@@ -131,6 +131,7 @@ void CHMSearchPanel::OnSearch(wxCommandEvent&)
 
     if (_titles->IsChecked() && h1.empty()) {
         PopulateList(_tcl->GetRootItem(), sr, !_partial->IsChecked());
+        _results->UpdateItemCount();
         _results->UpdateUI();
         return;
     }
@@ -140,6 +141,7 @@ void CHMSearchPanel::OnSearch(wxCommandEvent&)
         _results->AddPairItem(item.second, url);
     }
 
+    _results->UpdateItemCount();
     _results->UpdateUI();
 }
 

--- a/src/chmsearchpanel.cpp
+++ b/src/chmsearchpanel.cpp
@@ -159,11 +159,9 @@ void CHMSearchPanel::PopulateList(wxTreeItemId root, const wxString& text, bool 
     }
 
     wxTreeItemIdValue cookie;
-    auto              child = _tcl->GetFirstChild(root, cookie);
 
-    for (auto i = 0UL; i < _tcl->GetChildrenCount(root, false); ++i) {
+    for (auto child = _tcl->GetFirstChild(root, cookie); child; child = _tcl->GetNextChild(root, cookie)) {
         PopulateList(child, text, wholeWords);
-        child = _tcl->GetNextChild(root, cookie);
     }
 }
 

--- a/src/hhcparser.cpp
+++ b/src/hhcparser.cpp
@@ -128,7 +128,7 @@ void HHCParser::parse(const char* chunk)
                 ++chunk;
                 continue;
             }
-            // falthrough
+            // fallthrough
         }
 
         if (_intag)


### PR DESCRIPTION
I tested xCHM on Windows with https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.2.1/wxWidgets-3.2.2.1-docs-chm.zip and fixed two problems:

1. selecting for example "access.h" in the index takes a very long time
2. loading the chm file takes a long time

I also fixed a wxWidgets assertion which occurred because xCHM was trying to change a read only combo box for bookmarks.