### PR TITLE
improve performance

### DIFF
--- a/src/chmframe.cpp
+++ b/src/chmframe.cpp
@@ -538,7 +538,9 @@ void CHMFrame::UpdateCHMInfo()
 
     if (_tcl->GetCount()) {
         _tcl->Unselect();
+        _tcl->Freeze();
         _tcl->DeleteChildren(_tcl->GetRootItem());
+        _tcl->Thaw();
     }
 
 #if !wxUSE_UNICODE

--- a/src/chmlistctrl.cpp
+++ b/src/chmlistctrl.cpp
@@ -96,17 +96,8 @@ void CHMListCtrl::UpdateUI()
 
 void CHMListCtrl::FindBestMatch(const wxString& title)
 {
-    wxListItem info;
-    info.SetColumn(0);
-
-    auto sz = GetItemCount();
-    auto tl = title.length();
-
-    for (decltype(sz) i = 0; i < sz; ++i) {
-        info.SetId(i);
-        GetItem(info);
-
-        if (!info.GetText().Left(tl).CmpNoCase(title)) {
+    for (size_t i = 0; i < _items.size(); ++i) {
+        if (!_items[i]->_title.Left(title.length()).CmpNoCase(title)) {
             EnsureVisible(i);
             SetItemState(i, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
             break;


### PR DESCRIPTION
I have vastly improved the performance of the index search. I also made the deletion of the tree control faster. It happens when you load a CHM file while you already have a file loaded, so it need to delete the existing tree first.