### PR TITLE
support selection and activation in tree controls

### DIFF
--- a/src/chmframe.cpp
+++ b/src/chmframe.cpp
@@ -35,11 +35,13 @@
 #include <wx/artprov.h>
 #include <wx/bitmap.h>
 #include <wx/busyinfo.h>
+#include <wx/config.h>
 #include <wx/filesys.h>
 #include <wx/fs_mem.h>
 #include <wx/imaglist.h>
 #include <wx/mimetype.h>
 #include <wx/statbox.h>
+#include <wx/treebase.h>
 #include <wx/utils.h>
 #include <wx/version.h>
 
@@ -407,9 +409,23 @@ void CHMFrame::OnBookmarkSel(wxCommandEvent& event)
     _nbhtml->LoadPageInCurrentView(wxT("file:") + chmf->ArchiveName() + wxT("#xchm:/") + *url);
 }
 
+void CHMFrame::OnItemActivated(wxTreeEvent& event)
+{
+    event.Skip();
+
+    LoadSelected(event.GetItem());
+    _nbhtml->GetCurrentPage()->SetFocus();
+}
+
 void CHMFrame::OnSelectionChanged(wxTreeEvent& event)
 {
-    auto id   = event.GetItem();
+    event.Skip();
+
+    LoadSelected(event.GetItem());
+}
+
+void CHMFrame::LoadSelected(wxTreeItemId id)
+{
     auto chmf = CHMInputStream::GetCache();
 
     if (id == _tcl->GetRootItem() || !chmf || !id.IsOk())
@@ -933,6 +949,7 @@ EVT_MENU(ID_ToggleToolbar, CHMFrame::OnToggleToolbar)
 EVT_BUTTON(ID_Add, CHMFrame::OnAddBookmark)
 EVT_BUTTON(ID_Remove, CHMFrame::OnRemoveBookmark)
 EVT_TREE_SEL_CHANGED(ID_TreeCtrl, CHMFrame::OnSelectionChanged)
+EVT_TREE_ITEM_ACTIVATED(ID_TreeCtrl, CHMFrame::OnItemActivated)
 EVT_COMBOBOX(ID_Bookmarks, CHMFrame::OnBookmarkSel)
 EVT_TEXT_ENTER(ID_Bookmarks, CHMFrame::OnBookmarkSel)
 EVT_CLOSE(CHMFrame::OnCloseWindow)

--- a/src/chmframe.h
+++ b/src/chmframe.h
@@ -195,8 +195,11 @@ protected:
     //! Called when the user chooses a bookmark from the wxChoice control.
     void OnBookmarkSel(wxCommandEvent& event);
 
-    //! Called when an item in the contents tree is clicked.
+    //! Called when an item in the contents tree is selected.
     void OnSelectionChanged(wxTreeEvent& event);
+
+    //! Called when an item in the contents tree is activated.
+    void OnItemActivated(wxTreeEvent& event);
 
     //! Cleanup code. This saves the window position and last open dir.
     void OnCloseWindow(wxCloseEvent& event);
@@ -228,6 +231,8 @@ private:
 
     //! Helper. Saves exit information (size, history, etc.)
     void SaveExitInfo();
+
+    void LoadSelected(wxTreeItemId id);
 
 private:
     CHMHtmlNotebook*                    _nbhtml;

--- a/src/chmhtmlwindow.cpp
+++ b/src/chmhtmlwindow.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <wx/clipbrd.h>
 #include <wx/dnd.h>
+#include <wx/event.h>
 #include <wx/filename.h>
 #include <wx/log.h>
 #include <wx/uri.h>

--- a/src/chmhtmlwindow.h
+++ b/src/chmhtmlwindow.h
@@ -22,6 +22,7 @@
 
 #include <chmfinddialog.h>
 #include <memory>
+#include <wx/event.h>
 #include <wx/html/htmlwin.h>
 #include <wx/menu.h>
 #include <wx/notebook.h>

--- a/src/chmindexpanel.cpp
+++ b/src/chmindexpanel.cpp
@@ -17,12 +17,13 @@
   MA 02110-1301, USA.
 */
 
+#include <chmhtmlnotebook.h>
 #include <chmhtmlwindow.h>
 #include <chmindexpanel.h>
 #include <chmlistctrl.h>
 #include <wx/sizer.h>
 
-CHMIndexPanel::CHMIndexPanel(wxWindow* parent, CHMHtmlNotebook* nbhtml) : wxPanel(parent)
+CHMIndexPanel::CHMIndexPanel(wxWindow* parent, CHMHtmlNotebook* nbhtml) : wxPanel(parent), _nbhtml(nbhtml)
 {
     auto sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -47,16 +48,21 @@ void CHMIndexPanel::SetNewFont(const wxFont& font)
     _lc->SetFont(font);
 }
 
-void CHMIndexPanel::OnIndexSelRet(wxCommandEvent&)
+void CHMIndexPanel::OnIndexSel(wxListEvent& event)
 {
+    event.Skip();
+
     if (_navigate)
-        _lc->LoadSelected();
+        _lc->LoadSelected(event.GetIndex());
 }
 
-void CHMIndexPanel::OnIndexSel(wxListEvent&)
+void CHMIndexPanel::OnItemActivated(wxListEvent& event)
 {
+    event.Skip();
+
     if (_navigate)
-        _lc->LoadSelected();
+        _lc->LoadSelected(event.GetIndex());
+    _nbhtml->GetCurrentPage()->SetFocus();
 }
 
 void CHMIndexPanel::OnText(wxCommandEvent&)
@@ -68,6 +74,6 @@ void CHMIndexPanel::OnText(wxCommandEvent&)
 
 BEGIN_EVENT_TABLE(CHMIndexPanel, wxPanel)
 EVT_TEXT(ID_SearchIndex, CHMIndexPanel::OnText)
-EVT_TEXT_ENTER(ID_SearchIndex, CHMIndexPanel::OnIndexSelRet)
 EVT_LIST_ITEM_SELECTED(ID_IndexClicked, CHMIndexPanel::OnIndexSel)
+EVT_LIST_ITEM_ACTIVATED(ID_IndexClicked, CHMIndexPanel::OnItemActivated)
 END_EVENT_TABLE()

--- a/src/chmindexpanel.cpp
+++ b/src/chmindexpanel.cpp
@@ -22,6 +22,7 @@
 #include <chmindexpanel.h>
 #include <chmlistctrl.h>
 #include <wx/sizer.h>
+#include <wx/textctrl.h>
 
 CHMIndexPanel::CHMIndexPanel(wxWindow* parent, CHMHtmlNotebook* nbhtml) : wxPanel(parent), _nbhtml(nbhtml)
 {
@@ -72,8 +73,18 @@ void CHMIndexPanel::OnText(wxCommandEvent&)
     _navigate = true;
 }
 
+void CHMIndexPanel::OnTextEnter(wxCommandEvent&)
+{
+    _navigate = false;
+    _lc->FindBestMatch(_text->GetLineText(0));
+    _lc->LoadSelected(_lc->GetFocusedItem());
+    _nbhtml->GetCurrentPage()->SetFocusFromKbd();
+    _navigate = true;
+}
+
 BEGIN_EVENT_TABLE(CHMIndexPanel, wxPanel)
 EVT_TEXT(ID_SearchIndex, CHMIndexPanel::OnText)
+EVT_TEXT_ENTER(ID_SearchIndex, CHMIndexPanel::OnTextEnter)
 EVT_LIST_ITEM_SELECTED(ID_IndexClicked, CHMIndexPanel::OnIndexSel)
 EVT_LIST_ITEM_ACTIVATED(ID_IndexClicked, CHMIndexPanel::OnItemActivated)
 END_EVENT_TABLE()

--- a/src/chmindexpanel.h
+++ b/src/chmindexpanel.h
@@ -71,6 +71,9 @@ protected:
     //! Called whenever the user types a letter in the textbox.
     void OnText(wxCommandEvent& event);
 
+    //! Called whenever the user presses enter in the textbox.
+    void OnTextEnter(wxCommandEvent& event);
+
 private:
     wxTextCtrl*      _text;
     CHMListCtrl*     _lc {nullptr};

--- a/src/chmindexpanel.h
+++ b/src/chmindexpanel.h
@@ -20,6 +20,7 @@
 #ifndef __CHMINDEXPANEL_H_
 #define __CHMINDEXPANEL_H_
 
+#include <wx/app.h>
 #include <wx/listctrl.h>
 #include <wx/panel.h>
 #include <wx/textctrl.h>
@@ -61,19 +62,20 @@ public:
     void SetNewFont(const wxFont& font);
 
 protected:
-    //! This gets called when the user clicks on a list item.
+    //! This gets called when the user selects a list item.
     void OnIndexSel(wxListEvent& event);
 
-    //! This gets called when the user presses enter on a list item.
-    void OnIndexSelRet(wxCommandEvent& event);
+    //! This gets called when the user activates a list item.
+    void OnItemActivated(wxListEvent& event);
 
     //! Called whenever the user types a letter in the textbox.
     void OnText(wxCommandEvent& event);
 
 private:
-    wxTextCtrl*  _text;
-    CHMListCtrl* _lc {nullptr};
-    bool         _navigate {true};
+    wxTextCtrl*      _text;
+    CHMListCtrl*     _lc {nullptr};
+    bool             _navigate {true};
+    CHMHtmlNotebook* _nbhtml;
 
 private:
     DECLARE_EVENT_TABLE()

--- a/src/chmlistctrl.cpp
+++ b/src/chmlistctrl.cpp
@@ -22,6 +22,7 @@
 #include <chmhtmlnotebook.h>
 #include <chminputstream.h>
 #include <chmlistctrl.h>
+#include <wx/listbase.h>
 #include <wx/settings.h>
 
 // Helper
@@ -100,6 +101,7 @@ void CHMListCtrl::FindBestMatch(const wxString& title)
         if (!_items[i]->_title.Left(title.length()).CmpNoCase(title)) {
             EnsureVisible(i);
             SetItemState(i, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
+            SetItemState(i, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
             break;
         }
     }

--- a/src/chmlistctrl.cpp
+++ b/src/chmlistctrl.cpp
@@ -35,7 +35,7 @@ int CompareItemPairs(CHMListPairItem* item1, CHMListPairItem* item2)
 // CHMListCtrl implementation
 
 CHMListCtrl::CHMListCtrl(wxWindow* parent, CHMHtmlNotebook* nbhtml, wxWindowID id)
-    : wxListCtrl(parent, id, wxDefaultPosition, wxDefaultSize,
+    : wxListView(parent, id, wxDefaultPosition, wxDefaultSize,
                  wxLC_VIRTUAL | wxLC_REPORT | wxLC_NO_HEADER | wxLC_SINGLE_SEL | wxLC_SORT_ASCENDING | wxSUNKEN_BORDER),
       _items(CompareItemPairs), _nbhtml(nbhtml)
 {
@@ -70,14 +70,8 @@ void CHMListCtrl::AddPairItem(const wxString& title, const wxString& url)
     _items.Add(new CHMListPairItem(title, url));
 }
 
-void CHMListCtrl::LoadSelected()
+void CHMListCtrl::LoadSelected(long item)
 {
-    auto item = -1L;
-    item      = GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-
-    if (item == -1L || item > static_cast<long>(_items.GetCount()) - 1)
-        return;
-
     auto chmf = CHMInputStream::GetCache();
 
     if (chmf) {
@@ -100,8 +94,8 @@ void CHMListCtrl::FindBestMatch(const wxString& title)
     for (size_t i = 0; i < _items.size(); ++i) {
         if (!_items[i]->_title.Left(title.length()).CmpNoCase(title)) {
             EnsureVisible(i);
-            SetItemState(i, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
-            SetItemState(i, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
+            Select(i);
+            Focus(i);
             break;
         }
     }

--- a/src/chmlistctrl.h
+++ b/src/chmlistctrl.h
@@ -53,7 +53,7 @@ int CompareItemPairs(CHMListPairItem* item1, CHMListPairItem* item2);
 */
 
 //! List control class meant to emulate the look and feel of a wxListBox.
-class CHMListCtrl : public wxListCtrl {
+class CHMListCtrl : public wxListView {
 
 public:
     /*!
@@ -85,7 +85,7 @@ public:
     void AddPairItem(const wxString& title, const wxString& url);
 
     //! Loads the page that corresponds to the item currently selected.
-    void LoadSelected();
+    void LoadSelected(long item);
 
     //! Should be called each time the list control's state changes.
     void UpdateUI();

--- a/src/chmsearchpanel.cpp
+++ b/src/chmsearchpanel.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <chmhtmlnotebook.h>
+#include <chmhtmlwindow.h>
 #include <chminputstream.h>
 #include <chmlistctrl.h>
 #include <chmsearchpanel.h>
@@ -31,7 +32,7 @@
 #include <wx/wx.h>
 
 CHMSearchPanel::CHMSearchPanel(wxWindow* parent, wxTreeCtrl* topics, CHMHtmlNotebook* nbhtml)
-    : wxPanel(parent), _tcl(topics)
+    : wxPanel(parent), _tcl(topics), _nbhtml(nbhtml)
 {
     auto sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -203,9 +204,19 @@ bool CHMSearchPanel::TitleSearch(const wxString& title, const wxString& text, bo
     return processedTokens;
 }
 
-void CHMSearchPanel::OnSearchSel(wxListEvent&)
+void CHMSearchPanel::OnSearchSel(wxListEvent& event)
 {
-    _results->LoadSelected();
+    event.Skip();
+
+    _results->LoadSelected(event.GetIndex());
+}
+
+void CHMSearchPanel::OnItemActivated(wxListEvent& event)
+{
+    event.Skip();
+
+    _results->LoadSelected(event.GetIndex());
+    _nbhtml->GetCurrentPage()->SetFocus();
 }
 
 void CHMSearchPanel::Reset()
@@ -241,6 +252,7 @@ void CHMSearchPanel::GetConfig()
 
 BEGIN_EVENT_TABLE(CHMSearchPanel, wxPanel)
 EVT_LIST_ITEM_SELECTED(ID_Results, CHMSearchPanel::OnSearchSel)
+EVT_LIST_ITEM_ACTIVATED(ID_Results, CHMSearchPanel::OnItemActivated)
 EVT_BUTTON(ID_SearchButton, CHMSearchPanel::OnSearch)
 EVT_TEXT_ENTER(ID_SearchText, CHMSearchPanel::OnSearch)
 END_EVENT_TABLE()

--- a/src/chmsearchpanel.h
+++ b/src/chmsearchpanel.h
@@ -78,8 +78,11 @@ protected:
     */
     void OnSearch(wxCommandEvent& event);
 
-    //! This gets called when the user clicks on a result.
+    //! This gets called when the user selects a result.
     void OnSearchSel(wxListEvent& event);
+
+    //! This gets called when the user activates a result.
+    void OnItemActivated(wxListEvent& event);
 
 private:
     //! Helper. Searches through the tree recursively.
@@ -95,12 +98,13 @@ private:
     void SetConfig();
 
 private:
-    wxTreeCtrl*  _tcl;
-    wxTextCtrl*  _text;
-    wxCheckBox*  _partial;
-    wxCheckBox*  _titles;
-    wxButton*    _search;
-    CHMListCtrl* _results;
+    wxTreeCtrl*      _tcl;
+    wxTextCtrl*      _text;
+    wxCheckBox*      _partial;
+    wxCheckBox*      _titles;
+    wxButton*        _search;
+    CHMListCtrl*     _results;
+    CHMHtmlNotebook* _nbhtml;
 
 private:
     DECLARE_EVENT_TABLE()


### PR DESCRIPTION
The first commit focuses the selected item, otherwise if you switch focus with tab and use arrow keys it jumps to the the top item.

Second commit adds support for activation in addition to selection. Activation happens with ENTER and double click. This makes keyboard navigation easier and fixes some problems like the inability to select an already selected item and the need to manually focus the HTML window with tab after selecting an item.