### PR TITLE
Support for .chi files that may be distributed together with .chm files

### DIFF
--- a/src/chmfile.cpp
+++ b/src/chmfile.cpp
@@ -26,11 +26,11 @@
 #include <chmlistctrl.h>
 #include <hhcparser.h>
 #include <wx/defs.h>
+#include <wx/filename.h>
 #include <wx/fontmap.h>
 #include <wx/progdlg.h>
 #include <wx/strconv.h>
 #include <wx/treectrl.h>
-#include <wx/filename.h>
 #include <wx/wx.h>
 #include <wxstringutils.h>
 
@@ -234,15 +234,16 @@ bool CHMFile::LoadCHM(const wxString& archiveName)
 
     if (!_chmFile)
         return false;
-    
+
     wxFileName chiFn(archiveName);
     chiFn.SetExt("chi");
     wxString chiName = chiFn.GetFullPath();
-    
+
     // There may be issues on case-sensitive systems (for example, "doc.chm" and "DOC.chi" in EXT family).
-    // However, these seem to be extremely rare and exotic cases, so complex logic to handle them is intentionally avoided.
+    // However, these seem to be extremely rare and exotic cases, so complex logic to handle them is intentionally
+    // avoided.
     _chmChiFile = chm_open(static_cast<const char*>(chiName.mb_str()));
-    
+
     if (!_chmChiFile)
         _chmChiFile = _chmFile;
 
@@ -262,12 +263,12 @@ void CHMFile::CloseCHM()
 {
     if (!_chmFile)
         return;
-    
+
     if (_chmChiFile != _chmFile)
         chm_close(_chmChiFile);
 
     chm_close(_chmFile);
-    _chmFile = nullptr;
+    _chmFile    = nullptr;
     _chmChiFile = nullptr;
 
     _cidMap.clear();
@@ -659,19 +660,18 @@ bool CHMFile::IndexSearch(const wxString& text, bool wholeWords, bool titlesOnly
 
     if (text.IsEmpty())
         return false;
-    
-    IndexSearchUnitsInfo uis;
-    uis.fileMain    = _chmFile;
-    uis.fileTopics  = _chmChiFile;
-    uis.fileStrings = _chmChiFile;
-    uis.fileUrltbl  = _chmChiFile;
-    uis.fileUrlstr  = _chmChiFile;
-    
-    if (   chm_resolve_object(uis.fileMain   , "/$FIftiMain", &uis.uiMain   ) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(uis.fileTopics , "/#TOPICS"   , &uis.uiTopics ) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(uis.fileStrings, "/#STRINGS"  , &uis.uiStrings) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(uis.fileUrltbl , "/#URLTBL"   , &uis.uiUrltbl ) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(uis.fileUrlstr , "/#URLSTR"   , &uis.uiUrlstr ) != CHM_RESOLVE_SUCCESS)
+
+    IndexSearchUnitsInfo uis {.fileMain    = _chmFile,
+                              .fileTopics  = _chmChiFile,
+                              .fileStrings = _chmChiFile,
+                              .fileUrltbl  = _chmChiFile,
+                              .fileUrlstr  = _chmChiFile};
+
+    if (chm_resolve_object(uis.fileMain, "/$FIftiMain", &uis.uiMain) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(uis.fileTopics, "/#TOPICS", &uis.uiTopics) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(uis.fileStrings, "/#STRINGS", &uis.uiStrings) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(uis.fileUrltbl, "/#URLTBL", &uis.uiUrltbl) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(uis.fileUrlstr, "/#URLSTR", &uis.uiUrlstr) != CHM_RESOLVE_SUCCESS)
         return false;
 
     constexpr size_t FTS_HEADER_LEN {0x32};
@@ -792,7 +792,7 @@ bool CHMFile::GetArchiveInfo()
 }
 
 uint32_t CHMFile::GetLeafNodeOffset(const wxString& text, uint32_t initialOffset, uint32_t buffSize, uint16_t treeDepth,
-                                    chmFile *file, chmUnitInfo* ui)
+                                    chmFile* file, chmUnitInfo* ui)
 {
     uint32_t test_offset {0};
     wxString word;
@@ -843,7 +843,7 @@ uint32_t CHMFile::GetLeafNodeOffset(const wxString& text, uint32_t initialOffset
 
 bool CHMFile::ProcessWLC(uint64_t wlc_count, uint64_t wlc_size, uint32_t wlc_offset, unsigned char ds, unsigned char dr,
                          unsigned char cs, unsigned char cr, unsigned char ls, unsigned char lr,
-                         IndexSearchUnitsInfo &uis, CHMSearchResults& results)
+                         IndexSearchUnitsInfo& uis, CHMSearchResults& results)
 {
     auto        wlc_bit = 7;
     uint64_t    index {0};

--- a/src/chmfile.cpp
+++ b/src/chmfile.cpp
@@ -30,6 +30,7 @@
 #include <wx/progdlg.h>
 #include <wx/strconv.h>
 #include <wx/treectrl.h>
+#include <wx/filename.h>
 #include <wx/wx.h>
 #include <wxstringutils.h>
 
@@ -233,6 +234,17 @@ bool CHMFile::LoadCHM(const wxString& archiveName)
 
     if (!_chmFile)
         return false;
+    
+    wxFileName chiFn(archiveName);
+    chiFn.SetExt("chi");
+    wxString chiName = chiFn.GetFullPath();
+    
+    // There may be issues on case-sensitive systems (for example, "doc.chm" and "DOC.chi" in EXT family).
+    // However, these seem to be extremely rare and exotic cases, so complex logic to handle them is intentionally avoided.
+    _chmChiFile = chm_open(static_cast<const char*>(chiName.mb_str()));
+    
+    if (!_chmChiFile)
+        _chmChiFile = _chmFile;
 
     _enc      = wxFONTENCODING_SYSTEM;
     _filename = archiveName;
@@ -250,9 +262,13 @@ void CHMFile::CloseCHM()
 {
     if (!_chmFile)
         return;
+    
+    if (_chmChiFile != _chmFile)
+        chm_close(_chmChiFile);
 
     chm_close(_chmFile);
     _chmFile = nullptr;
+    _chmChiFile = nullptr;
 
     _cidMap.clear();
     _home     = wxT("/");
@@ -267,11 +283,11 @@ bool CHMFile::BinaryTOC(wxTreeCtrl& toBuild)
 {
     chmUnitInfo ti_ui, ts_ui, st_ui, ut_ui, us_ui;
 
-    if (chm_resolve_object(_chmFile, "/#TOCIDX", &ti_ui) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#TOPICS", &ts_ui) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#STRINGS", &st_ui) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#URLTBL", &ut_ui) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#URLSTR", &us_ui) != CHM_RESOLVE_SUCCESS)
+    if (chm_resolve_object(_chmChiFile, "/#TOCIDX", &ti_ui) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(_chmChiFile, "/#TOPICS", &ts_ui) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(_chmChiFile, "/#STRINGS", &st_ui) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(_chmChiFile, "/#URLTBL", &ut_ui) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(_chmChiFile, "/#URLSTR", &us_ui) != CHM_RESOLVE_SUCCESS)
         return false; // failed to find internal files
 
     if (ti_ui.length < 4)
@@ -280,11 +296,11 @@ bool CHMFile::BinaryTOC(wxTreeCtrl& toBuild)
     UCharVector topidx(ti_ui.length), topics(ts_ui.length), strings(st_ui.length), urltbl(ut_ui.length),
         urlstr(us_ui.length);
 
-    if (chm_retrieve_object(_chmFile, &ti_ui, &topidx[0], 0, ti_ui.length) != static_cast<int64_t>(ti_ui.length)
-        || chm_retrieve_object(_chmFile, &ts_ui, &topics[0], 0, ts_ui.length) != static_cast<int64_t>(ts_ui.length)
-        || chm_retrieve_object(_chmFile, &st_ui, &strings[0], 0, st_ui.length) != static_cast<int64_t>(st_ui.length)
-        || chm_retrieve_object(_chmFile, &ut_ui, &urltbl[0], 0, ut_ui.length) != static_cast<int64_t>(ut_ui.length)
-        || chm_retrieve_object(_chmFile, &us_ui, &urlstr[0], 0, us_ui.length) != static_cast<int64_t>(us_ui.length))
+    if (chm_retrieve_object(_chmChiFile, &ti_ui, &topidx[0], 0, ti_ui.length) != static_cast<int64_t>(ti_ui.length)
+        || chm_retrieve_object(_chmChiFile, &ts_ui, &topics[0], 0, ts_ui.length) != static_cast<int64_t>(ts_ui.length)
+        || chm_retrieve_object(_chmChiFile, &st_ui, &strings[0], 0, st_ui.length) != static_cast<int64_t>(st_ui.length)
+        || chm_retrieve_object(_chmChiFile, &ut_ui, &urltbl[0], 0, ut_ui.length) != static_cast<int64_t>(ut_ui.length)
+        || chm_retrieve_object(_chmChiFile, &us_ui, &urlstr[0], 0, us_ui.length) != static_cast<int64_t>(us_ui.length))
         return false;
 
     auto off = UINT32_FROM_ARRAY(&topidx[0]);
@@ -444,21 +460,21 @@ bool CHMFile::BinaryIndex(CHMListCtrl& toBuild, const wxCSConv& cv)
     chmUnitInfo bt_ui, ts_ui, st_ui, ut_ui, us_ui;
     auto        items = 0UL;
 
-    if (chm_resolve_object(_chmFile, "/$WWKeywordLinks/BTree", &bt_ui) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#TOPICS", &ts_ui) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#STRINGS", &st_ui) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#URLTBL", &ut_ui) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#URLSTR", &us_ui) != CHM_RESOLVE_SUCCESS)
+    if (chm_resolve_object(_chmChiFile, "/$WWKeywordLinks/BTree", &bt_ui) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(_chmChiFile, "/#TOPICS", &ts_ui) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(_chmChiFile, "/#STRINGS", &st_ui) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(_chmChiFile, "/#URLTBL", &ut_ui) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(_chmChiFile, "/#URLSTR", &us_ui) != CHM_RESOLVE_SUCCESS)
         return false; // failed to find internal files
 
     UCharVector btree(bt_ui.length), topics(ts_ui.length), strings(st_ui.length), urltbl(ut_ui.length),
         urlstr(us_ui.length);
 
-    if (chm_retrieve_object(_chmFile, &bt_ui, &btree[0], 0, bt_ui.length) != (int64_t)bt_ui.length
-        || chm_retrieve_object(_chmFile, &ts_ui, &topics[0], 0, ts_ui.length) != (int64_t)ts_ui.length
-        || chm_retrieve_object(_chmFile, &st_ui, &strings[0], 0, st_ui.length) != (int64_t)st_ui.length
-        || chm_retrieve_object(_chmFile, &ut_ui, &urltbl[0], 0, ut_ui.length) != (int64_t)ut_ui.length
-        || chm_retrieve_object(_chmFile, &us_ui, &urlstr[0], 0, us_ui.length) != (int64_t)us_ui.length)
+    if (chm_retrieve_object(_chmChiFile, &bt_ui, &btree[0], 0, bt_ui.length) != (int64_t)bt_ui.length
+        || chm_retrieve_object(_chmChiFile, &ts_ui, &topics[0], 0, ts_ui.length) != (int64_t)ts_ui.length
+        || chm_retrieve_object(_chmChiFile, &st_ui, &strings[0], 0, st_ui.length) != (int64_t)st_ui.length
+        || chm_retrieve_object(_chmChiFile, &ut_ui, &urltbl[0], 0, ut_ui.length) != (int64_t)ut_ui.length
+        || chm_retrieve_object(_chmChiFile, &us_ui, &urlstr[0], 0, us_ui.length) != (int64_t)us_ui.length)
         return false;
 
     if (bt_ui.length < 0x4c + 12)
@@ -585,7 +601,7 @@ bool CHMFile::LoadContextIDs()
     // make sure what we need is there.
     // #IVB has list of context ID's and #STRINGS offsets to file names.
     if (chm_resolve_object(_chmFile, "/#IVB", &ivb_ui) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#STRINGS", &strs_ui) != CHM_RESOLVE_SUCCESS)
+        || chm_resolve_object(_chmChiFile, "/#STRINGS", &strs_ui) != CHM_RESOLVE_SUCCESS)
         return false; // failed to find internal files
 
     UCharVector ivb_buf(ivb_ui.length);
@@ -611,7 +627,7 @@ bool CHMFile::LoadContextIDs()
 
     UCharVector strs_buf(strs_ui.length);
 
-    if (chm_retrieve_object(_chmFile, &strs_ui, &strs_buf[0], 0, strs_ui.length) == 0)
+    if (chm_retrieve_object(_chmChiFile, &strs_ui, &strs_buf[0], 0, strs_ui.length) == 0)
         return false; // failed to retrieve data
 
     for (unsigned int i = 0; i < ivb_len; i += 2)
@@ -643,19 +659,25 @@ bool CHMFile::IndexSearch(const wxString& text, bool wholeWords, bool titlesOnly
 
     if (text.IsEmpty())
         return false;
-
-    chmUnitInfo ui, uitopics, uiurltbl, uistrings, uiurlstr;
-    if (chm_resolve_object(_chmFile, "/$FIftiMain", &ui) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#TOPICS", &uitopics) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#STRINGS", &uistrings) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#URLTBL", &uiurltbl) != CHM_RESOLVE_SUCCESS
-        || chm_resolve_object(_chmFile, "/#URLSTR", &uiurlstr) != CHM_RESOLVE_SUCCESS)
+    
+    IndexSearchUnitsInfo uis;
+    uis.fileMain    = _chmFile;
+    uis.fileTopics  = _chmChiFile;
+    uis.fileStrings = _chmChiFile;
+    uis.fileUrltbl  = _chmChiFile;
+    uis.fileUrlstr  = _chmChiFile;
+    
+    if (   chm_resolve_object(uis.fileMain   , "/$FIftiMain", &uis.uiMain   ) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(uis.fileTopics , "/#TOPICS"   , &uis.uiTopics ) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(uis.fileStrings, "/#STRINGS"  , &uis.uiStrings) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(uis.fileUrltbl , "/#URLTBL"   , &uis.uiUrltbl ) != CHM_RESOLVE_SUCCESS
+        || chm_resolve_object(uis.fileUrlstr , "/#URLSTR"   , &uis.uiUrlstr ) != CHM_RESOLVE_SUCCESS)
         return false;
 
     constexpr size_t FTS_HEADER_LEN {0x32};
     unsigned char    header[FTS_HEADER_LEN];
 
-    if (chm_retrieve_object(_chmFile, &ui, header, 0, FTS_HEADER_LEN) == 0)
+    if (chm_retrieve_object(uis.fileMain, &uis.uiMain, header, 0, FTS_HEADER_LEN) == 0)
         return false;
 
     auto doc_index_s = header[0x1E], doc_index_r = header[0x1F], code_count_s = header[0x20],
@@ -677,14 +699,14 @@ bool CHMFile::IndexSearch(const wxString& text, bool wholeWords, bool titlesOnly
     wxString    word;
     UCharVector buffer(node_len);
 
-    node_offset = GetLeafNodeOffset(text, node_offset, node_len, tree_depth, &ui);
+    node_offset = GetLeafNodeOffset(text, node_offset, node_len, tree_depth, uis.fileMain, &uis.uiMain);
 
     if (!node_offset)
         return false;
 
     do {
         // got a leaf node here.
-        if (chm_retrieve_object(_chmFile, &ui, &buffer[0], node_offset, node_len) == 0)
+        if (chm_retrieve_object(uis.fileMain, &uis.uiMain, &buffer[0], node_offset, node_len) == 0)
             return false;
 
         cursor16        = &buffer[6];
@@ -729,13 +751,13 @@ bool CHMFile::IndexSearch(const wxString& text, bool wholeWords, bool titlesOnly
 
             if (wholeWords && !text.CmpNoCase(word))
                 return ProcessWLC(wlc_count, wlc_size, wlc_offset, doc_index_s, doc_index_r, code_count_s, code_count_r,
-                                  loc_codes_s, loc_codes_r, &ui, &uiurltbl, &uistrings, &uitopics, &uiurlstr, results);
+                                  loc_codes_s, loc_codes_r, uis, results);
 
             if (!wholeWords) {
                 if (word.StartsWith(text.c_str())) {
                     partial = true;
                     ProcessWLC(wlc_count, wlc_size, wlc_offset, doc_index_s, doc_index_r, code_count_s, code_count_r,
-                               loc_codes_s, loc_codes_r, &ui, &uiurltbl, &uistrings, &uitopics, &uiurlstr, results);
+                               loc_codes_s, loc_codes_r, uis, results);
 
                 } else if (text.CmpNoCase(word.Mid(0, text.Length())) < -1)
                     break;
@@ -770,7 +792,7 @@ bool CHMFile::GetArchiveInfo()
 }
 
 uint32_t CHMFile::GetLeafNodeOffset(const wxString& text, uint32_t initialOffset, uint32_t buffSize, uint16_t treeDepth,
-                                    chmUnitInfo* ui)
+                                    chmFile *file, chmUnitInfo* ui)
 {
     uint32_t test_offset {0};
     wxString word;
@@ -785,7 +807,7 @@ uint32_t CHMFile::GetLeafNodeOffset(const wxString& text, uint32_t initialOffset
             return 0;
 
         test_offset = initialOffset;
-        if (chm_retrieve_object(_chmFile, ui, &buffer[0], initialOffset, buffSize) == 0)
+        if (chm_retrieve_object(file, ui, &buffer[0], initialOffset, buffSize) == 0)
             return 0;
 
         auto     cursor16   = &buffer[0];
@@ -820,9 +842,8 @@ uint32_t CHMFile::GetLeafNodeOffset(const wxString& text, uint32_t initialOffset
 }
 
 bool CHMFile::ProcessWLC(uint64_t wlc_count, uint64_t wlc_size, uint32_t wlc_offset, unsigned char ds, unsigned char dr,
-                         unsigned char cs, unsigned char cr, unsigned char ls, unsigned char lr, chmUnitInfo* uimain,
-                         chmUnitInfo* uitbl, chmUnitInfo* uistrings, chmUnitInfo* topics, chmUnitInfo* urlstr,
-                         CHMSearchResults& results)
+                         unsigned char cs, unsigned char cr, unsigned char ls, unsigned char lr,
+                         IndexSearchUnitsInfo &uis, CHMSearchResults& results)
 {
     auto        wlc_bit = 7;
     uint64_t    index {0};
@@ -835,7 +856,7 @@ bool CHMFile::ProcessWLC(uint64_t wlc_count, uint64_t wlc_size, uint32_t wlc_off
     constexpr size_t COMMON_BUF_LEN {1025};
     unsigned char    combuf[COMMON_BUF_LEN];
 
-    if (chm_retrieve_object(_chmFile, uimain, &buffer[0], wlc_offset, wlc_size) == 0)
+    if (chm_retrieve_object(uis.fileMain, &uis.uiMain, &buffer[0], wlc_offset, wlc_size) == 0)
         return false;
 
     for (uint64_t i = 0; i < wlc_count; ++i) {
@@ -847,7 +868,7 @@ bool CHMFile::ProcessWLC(uint64_t wlc_count, uint64_t wlc_size, uint32_t wlc_off
         index += sr_int(&buffer[off], &wlc_bit, ds, dr, length);
         off += length;
 
-        if (chm_retrieve_object(_chmFile, topics, entry, index * 16, TOPICS_ENTRY_LEN) == 0)
+        if (chm_retrieve_object(uis.fileTopics, &uis.uiTopics, entry, index * 16, TOPICS_ENTRY_LEN) == 0)
             return false;
 
         auto cursor32              = entry + 4;
@@ -856,7 +877,7 @@ bool CHMFile::ProcessWLC(uint64_t wlc_count, uint64_t wlc_size, uint32_t wlc_off
 
         wxString topic;
 
-        if (chm_retrieve_object(_chmFile, uistrings, combuf, stroff, COMMON_BUF_LEN - 1) == 0)
+        if (chm_retrieve_object(uis.fileStrings, &uis.uiStrings, combuf, stroff, COMMON_BUF_LEN - 1) == 0)
             topic = EMPTY_INDEX;
         else {
             combuf[COMMON_BUF_LEN - 1] = 0;
@@ -876,13 +897,13 @@ bool CHMFile::ProcessWLC(uint64_t wlc_count, uint64_t wlc_size, uint32_t wlc_off
         cursor32    = entry + 8;
         auto urloff = UINT32_FROM_ARRAY(cursor32);
 
-        if (chm_retrieve_object(_chmFile, uitbl, combuf, urloff, 12) == 0)
+        if (chm_retrieve_object(uis.fileUrltbl, &uis.uiUrltbl, combuf, urloff, 12) == 0)
             return false;
 
         cursor32 = combuf + 8;
         urloff   = UINT32_FROM_ARRAY(cursor32);
 
-        if (chm_retrieve_object(_chmFile, urlstr, combuf, urloff + 8, COMMON_BUF_LEN - 1) == 0)
+        if (chm_retrieve_object(uis.fileUrlstr, &uis.uiUrlstr, combuf, urloff + 8, COMMON_BUF_LEN - 1) == 0)
             return false;
 
         combuf[COMMON_BUF_LEN - 1] = 0;
@@ -912,11 +933,11 @@ bool CHMFile::InfoFromWindows()
     constexpr size_t WIN_HEADER_LEN {0x08};
     chmUnitInfo      ui;
 
-    if (chm_resolve_object(_chmFile, "/#WINDOWS", &ui) == CHM_RESOLVE_SUCCESS) {
+    if (chm_resolve_object(_chmChiFile, "/#WINDOWS", &ui) == CHM_RESOLVE_SUCCESS) {
         unsigned char buffer[BUF_SIZE];
         auto          size = 0L;
 
-        if (!chm_retrieve_object(_chmFile, &ui, buffer, 0, WIN_HEADER_LEN))
+        if (!chm_retrieve_object(_chmChiFile, &ui, buffer, 0, WIN_HEADER_LEN))
             return false;
 
         auto entries    = UINT32_FROM_ARRAY(buffer);
@@ -925,10 +946,10 @@ bool CHMFile::InfoFromWindows()
         UCharVector uptr(entries * entry_size);
         auto        raw = &uptr[0];
 
-        if (!chm_retrieve_object(_chmFile, &ui, raw, 8, entries * entry_size))
+        if (!chm_retrieve_object(_chmChiFile, &ui, raw, 8, entries * entry_size))
             return false;
 
-        if (chm_resolve_object(_chmFile, "/#STRINGS", &ui) != CHM_RESOLVE_SUCCESS)
+        if (chm_resolve_object(_chmChiFile, "/#STRINGS", &ui) != CHM_RESOLVE_SUCCESS)
             return false;
 
         for (uint32_t i = 0; i < entries; ++i) {
@@ -940,14 +961,14 @@ bool CHMFile::InfoFromWindows()
             auto     factor    = off_title / 4096;
 
             if (size == 0)
-                size = chm_retrieve_object(_chmFile, &ui, buffer, factor * 4096, BUF_SIZE);
+                size = chm_retrieve_object(_chmChiFile, &ui, buffer, factor * 4096, BUF_SIZE);
 
             if (size && off_title)
                 _title = CURRENT_CHAR_STRING(buffer + off_title % 4096);
 
             if (factor != off_home / 4096) {
                 factor = off_home / 4096;
-                size   = chm_retrieve_object(_chmFile, &ui, buffer, factor * 4096, BUF_SIZE);
+                size   = chm_retrieve_object(_chmChiFile, &ui, buffer, factor * 4096, BUF_SIZE);
             }
 
             if (size && off_home)
@@ -955,7 +976,7 @@ bool CHMFile::InfoFromWindows()
 
             if (factor != off_hhc / 4096) {
                 factor = off_hhc / 4096;
-                size   = chm_retrieve_object(_chmFile, &ui, buffer, factor * 4096, BUF_SIZE);
+                size   = chm_retrieve_object(_chmChiFile, &ui, buffer, factor * 4096, BUF_SIZE);
             }
 
             if (size && off_hhc)
@@ -963,7 +984,7 @@ bool CHMFile::InfoFromWindows()
 
             if (factor != off_hhk / 4096) {
                 factor = off_hhk / 4096;
-                size   = chm_retrieve_object(_chmFile, &ui, buffer, factor * 4096, BUF_SIZE);
+                size   = chm_retrieve_object(_chmChiFile, &ui, buffer, factor * 4096, BUF_SIZE);
             }
 
             if (size && off_hhk)

--- a/src/chmfile.h
+++ b/src/chmfile.h
@@ -203,13 +203,31 @@ private:
 
     //! Helper. Returns the $FIftiMain offset of leaf node or 0.
     uint32_t GetLeafNodeOffset(const wxString& text, uint32_t initalOffset, uint32_t buffSize, uint16_t treeDepth,
-                               chmUnitInfo* ui);
-
+                               chmFile *file, chmUnitInfo* ui);
+    
+    //! Helper. To avoid a large list of parameters in 'ProcessWLC', and slightly improve readability
+    struct IndexSearchUnitsInfo
+    {
+        chmFile *fileMain;
+        chmUnitInfo uiMain;
+        
+        chmFile *fileUrltbl;
+        chmUnitInfo uiUrltbl;
+        
+        chmFile *fileStrings;
+        chmUnitInfo uiStrings;
+        
+        chmFile *fileTopics;
+        chmUnitInfo uiTopics;
+        
+        chmFile *fileUrlstr;
+        chmUnitInfo uiUrlstr;
+    };
+    
     //! Helper. Processes the word location code entries while searching.
     bool ProcessWLC(uint64_t wlc_count, uint64_t wlc_size, uint32_t wlc_offset, unsigned char ds, unsigned char dr,
-                    unsigned char cs, unsigned char cr, unsigned char ls, unsigned char lr, chmUnitInfo* uifmain,
-                    chmUnitInfo* uitbl, chmUnitInfo* uistrings, chmUnitInfo* topics, chmUnitInfo* urlstr,
-                    CHMSearchResults& results);
+                    unsigned char cs, unsigned char cr, unsigned char ls, unsigned char lr,
+                    IndexSearchUnitsInfo &uis, CHMSearchResults& results);
 
     //! Looks up as much information as possible from #WINDOWS/#STRINGS.
     bool InfoFromWindows();
@@ -232,7 +250,8 @@ private:
     bool BinaryIndex(CHMListCtrl& toBuild, const wxCSConv& cv);
 
 private:
-    chmFile*       _chmFile {nullptr};
+    chmFile*       _chmFile    {nullptr};
+    chmFile*       _chmChiFile {nullptr};
     wxString       _filename;
     wxString       _home {wxT("/")};
     wxString       _topicsFile;

--- a/src/chmfile.h
+++ b/src/chmfile.h
@@ -51,6 +51,24 @@ WX_DECLARE_HASH_MAP(int, wxString, wxIntegerHash, wxIntegerEqual, CHMIDMap);
 
 //! C++ wrapper around CHMLIB. Concrete class.
 class CHMFile {
+    //! Helper. To avoid a large list of parameters in 'ProcessWLC', and slightly improve readability
+    struct IndexSearchUnitsInfo {
+        chmFile*    fileMain;
+        chmUnitInfo uiMain {};
+
+        chmFile*    fileTopics;
+        chmUnitInfo uiTopics {};
+
+        chmFile*    fileStrings;
+        chmUnitInfo uiStrings {};
+
+        chmFile*    fileUrltbl;
+        chmUnitInfo uiUrltbl {};
+
+        chmFile*    fileUrlstr;
+        chmUnitInfo uiUrlstr {};
+    };
+
 public:
     //! Default constructor.
     CHMFile() = default;
@@ -203,31 +221,12 @@ private:
 
     //! Helper. Returns the $FIftiMain offset of leaf node or 0.
     uint32_t GetLeafNodeOffset(const wxString& text, uint32_t initalOffset, uint32_t buffSize, uint16_t treeDepth,
-                               chmFile *file, chmUnitInfo* ui);
-    
-    //! Helper. To avoid a large list of parameters in 'ProcessWLC', and slightly improve readability
-    struct IndexSearchUnitsInfo
-    {
-        chmFile *fileMain;
-        chmUnitInfo uiMain;
-        
-        chmFile *fileUrltbl;
-        chmUnitInfo uiUrltbl;
-        
-        chmFile *fileStrings;
-        chmUnitInfo uiStrings;
-        
-        chmFile *fileTopics;
-        chmUnitInfo uiTopics;
-        
-        chmFile *fileUrlstr;
-        chmUnitInfo uiUrlstr;
-    };
-    
+                               chmFile* file, chmUnitInfo* ui);
+
     //! Helper. Processes the word location code entries while searching.
     bool ProcessWLC(uint64_t wlc_count, uint64_t wlc_size, uint32_t wlc_offset, unsigned char ds, unsigned char dr,
-                    unsigned char cs, unsigned char cr, unsigned char ls, unsigned char lr,
-                    IndexSearchUnitsInfo &uis, CHMSearchResults& results);
+                    unsigned char cs, unsigned char cr, unsigned char ls, unsigned char lr, IndexSearchUnitsInfo& uis,
+                    CHMSearchResults& results);
 
     //! Looks up as much information as possible from #WINDOWS/#STRINGS.
     bool InfoFromWindows();
@@ -250,7 +249,7 @@ private:
     bool BinaryIndex(CHMListCtrl& toBuild, const wxCSConv& cv);
 
 private:
-    chmFile*       _chmFile    {nullptr};
+    chmFile*       _chmFile {nullptr};
     chmFile*       _chmChiFile {nullptr};
     wxString       _filename;
     wxString       _home {wxT("/")};


### PR DESCRIPTION
I have encountered this behavior before (a **.chi** distributed together with a **.chm**), and i am currently working with such documentation as well. 
Additionally, a Doxygen project can use the **"GENERATE_CHI"** option, which results in adding the **"Create CHI file=YES"** option for **hhc.exe**, consequently, a **.chi** file will be generated alongside the **.chm**.

My brief research on this feature and the conclusions i have come to:
1. **hh.exe**, when opening documentation (any documentation), queries the file system before reading anything to check for the presence of the **.chm** file itself and also for the presence of a **.chi** file next to it. 
No other files are queried. 
I can confidently conclude that information about whether a **.chi** file is present or not is neither explicitly nor implicitly stored inside the original **.chm**. I have also reviewed unofficial documentation on the format, and didnt found anything about it. 
This is also confirmed by the ability to slip a foreign **.chi** file next to a **.chm** (which was compiled without **.chi**) and then see a foreign table of contents and other data on the left side in the **hh.exe**. 
2. A complete and fixed list of files that are exported to **.chi** <ins>_instead_</ins> of **.chm**:
**$WWAssociativeLinks** (and everything else in this directory)
**$WWKeywordLinks** (and everything else in this directory)
**#IDXHDR**
**#ITBITS**
**#STRINGS**
**#SYSTEM** (present in both **.chm** and **.chi** and is completely identical)
**#TOCIDX**
**#TOPICS**
**#URLSTR**
**#URLTBL**
**#WINDOWS**
**$OBJINST**
This list is always constant — both for completely empty **.hhp** projects and for large documentation sets.
3. If some files are missing in the **.chi**, then they will also be missing in the **.chm**. 
**#TOCIDX** for example (**"Binary TOC=No"**). 
5. **#SYSTEM** is an exception from **2.**, and this is done solely to ensure that the **.chi** really belongs to this **.chm**. 
**hh.exe** is also aware of this and offers to either continue loading or abort.
This case is clearly exotic, so i think there is no need to overcomplicate things, and **#SYSTEM** should be loaded as usual from the **.chm**.

Summarizing all these points, i came to the conclusion that this feature is most likely unique in its own way. 
There is therefore no need to implement any complex runtime logic for merging multiple **ITSF** files into a single entity. 
So it is sufficient to get by with a few minor tweaks, which are essentially transparent in nature.

This patch was tested both on documentations that contain only a **.chm** and on those that have a **.chm** together with a **.chi**, and everything works absolutely perfectly!
I am very glad that i can now take full advantage of the capabilities of your program 😁.

And one more thing
It would be great to add this information and research to the unofficial documentation at https://www.nongnu.org/chmspec/latest/index.html. 
I only found a CVS repository and a link to the IRC channel. 
Please dont take this as impertinence, but if it is easier for you to do this than for me (i found your contact in the list of contributors to the documentation, and perhaps you still keep in touch with the documentation author), i would be very grateful. If you decline, i will understand and will try to do it myself.

